### PR TITLE
NOISSUE - Refactor fan-in scenario

### DIFF
--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -18,7 +18,7 @@
 #######
 
 defaults(
-        "PUB_SIZE" = 10000,
+        "PUB_NUM" = 10000,
         "PUB_TIME" = 5,
         "PUB_RATE" = 1,
         "MSG_SIZE" = 100,
@@ -51,9 +51,9 @@ pool(size = 1,
             subscribe(sprintf("channels/~s/messages/#", [var("MF_CHANNEL_ID")]), numvar("QOS"))
 
 
-pool(size = numvar("PUB_SIZE"),
+pool(size = numvar("PUB_NUM"),
      worker_type = mqtt_worker,
-     worker_start = poisson(numvar("PUB_SIZE") rps)):
+     worker_start = poisson(numvar("PUB_NUM") rps)):
             connect([t(host, var("MF_MQTT_ENDPOINT")),
                     t(port, numvar("MF_MQTT_PORT")),
                     t(client,fixed_client_id("publisher", worker_id())),
@@ -65,7 +65,7 @@ pool(size = numvar("PUB_SIZE"),
                     ])
 
             set_signal(connect1, 1)
-            wait_signal(connect1, numvar("PUB_SIZE"))
+            wait_signal(connect1, numvar("PUB_NUM"))
             wait(5 sec)
             loop(time = numvar("PUB_TIME") min, rate = numvar("PUB_RATE") rps):
                 publish_to_self(sprintf("channels/~s/messages/", [var("MF_CHANNEL_ID")]), random_binary(numvar("MSG_SIZE")), numvar("QOS"))

--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -22,7 +22,7 @@ make_install(git = "https://github.com/erlio/vmq_mzbench.git",
 
 pool(size = 1,
      worker_type = mqtt_worker):
-            connect([t(host, "<MF_MQTT_ENDPOINT"),
+            connect([t(host, "<MF_MQTT_ENDPOINT>"),
                     t(port, 1883),
                     t(client,"subscriber1"),
                     t(clean_session,true),
@@ -39,7 +39,7 @@ pool(size = 1,
 pool(size = 10000,
      worker_type = mqtt_worker,
      worker_start = poisson(10000 rps)):
-            connect([t(host, "157.245.26.18"),
+            connect([t(host, "<MF_MQTT_ENDPOINT>"),
                     t(port, 1883),
                     t(client,fixed_client_id("publisher-", worker_id())),
                     t(clean_session,true),
@@ -50,7 +50,7 @@ pool(size = 10000,
                     ])
 
             set_signal(connect1, 1)
-            wait_signal(connect1, 100)
+            wait_signal(connect1, 10000)
             wait(5 sec)
             loop(time = 5 min, rate = 1 rps):
                 publish_to_self("<MF_CHANNEL>/", random_binary(100), 2)

--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -14,7 +14,7 @@
 # <MF_THING_1_KEY> = First thing key of pre-provisioned Mainflux thing
 # <MF_THING_2_ID> = Second thing ID of pre-provisioned Mainflux thing
 # <MF_THING_2_KEY> = Second thing key of pre-provisioned Mainflux thing.
-# <MF_CHANNEL> = pre-provisioned channel where thing is connected
+# <MF_CHANNEL_ID> = pre-provisioned channel id where things are connected
 #######
 
 defaults(

--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -2,31 +2,31 @@
 
 #######
 # Scenario:
-# A single subscriber reading from "channels/<MF_CHANNEL_ID>/messages/#" topic
-# 10000 publisher publishing to exclusive topic "channels/<MF_CHANNEL_ID>/messages/<client_id>"
+# A single subscriber reading from "channels/<MZBENCH_MF_CHANNEL_ID>/messages/#" topic
+# 10000 publisher publishing to exclusive topic "channels/<MZBENCH_MF_CHANNEL_ID>/messages/<client_id>"
 # Overall msg rate: 10 000 msg/s
 # Message size: 100 random bytes
 # Running time: 5 min
 # QoS level: 2
 # NOTE: Scenario's values can be changed with environment variables predefined in defaults
 # Set environment variables to connect to Mainflux instance:
-# MF_MQTT_ENPOINT = IP/domain of MQTT endpoint on Mainflux
-# MF_MQTT_PORT = Port of MQTT endpoint on Mainflux
-# MF_THING_1_ID = First thing ID of pre-provisioned Mainflux thing
-# MF_THING_1_KEY = First thing key of pre-provisioned Mainflux thing
-# MF_THING_2_ID = Second thing ID of pre-provisioned Mainflux thing
-# MF_THING_2_KEY = Second thing key of pre-provisioned Mainflux thing.
-# MF_CHANNEL_ID = ID of pre-provisioned channel on which both things are connected
+# MZBENCH_MF_MQTT_ENPOINT = IP/domain of MQTT endpoint on Mainflux
+# MZBENCH_MF_MQTT_PORT = Port of MQTT endpoint on Mainflux
+# MZBENCH_MF_THING_1_ID = First thing ID of pre-provisioned Mainflux thing
+# MZBENCH_MF_THING_1_KEY = First thing key of pre-provisioned Mainflux thing
+# MZBENCH_MF_THING_2_ID = Second thing ID of pre-provisioned Mainflux thing
+# MZBENCH_MF_THING_2_KEY = Second thing key of pre-provisioned Mainflux thing.
+# MZBENCH_MF_CHANNEL_ID = ID of pre-provisioned channel on which both things are connected
 #######
 
 defaults(
-        "PUB_NUM" = 10000,
-        "PUB_TIME" = 5,
-        "PUB_RATE" = 1,
-        "MSG_SIZE" = 100,
-        "QOS" = 2,
-        "MF_MQTT_ENDPOINT" = "127.0.0.1",
-        "MF_MQTT_PORT" = 1883
+        "MZBENCH_PUB_NUM" = 10000,
+        "MZBENCH_PUB_TIME" = 5,
+        "MZBENCH_PUB_RATE" = 1,
+        "MZBENCH_MSG_SIZE" = 100,
+        "MZBENCH_QOS" = 2,
+        "MZBENCH_MF_MQTT_ENDPOINT" = "127.0.0.1",
+        "MZBENCH_MF_MQTT_PORT" = 1883
 )
 
 make_install(git = "https://github.com/erlio/vmq_mzbench.git",
@@ -34,36 +34,36 @@ make_install(git = "https://github.com/erlio/vmq_mzbench.git",
 
 pool(size = 1,
      worker_type = mqtt_worker):
-            connect([t(host, var("MF_MQTT_ENDPOINT")),
-                    t(port, numvar("MF_MQTT_PORT")),
+            connect([t(host, var("MZBENCH_MF_MQTT_ENDPOINT")),
+                    t(port, numvar("MZBENCH_MF_MQTT_PORT")),
                     t(client,"subscriber1"),
                     t(clean_session,true),
                     t(keepalive_interval,60),
-                    t(username, var("MF_THING_1_ID")),
-                    t(password, var("MF_THING_1_KEY")),
+                    t(username, var("MZBENCH_MF_THING_1_ID")),
+                    t(password, var("MZBENCH_MF_THING_1_KEY")),
                     t(proto_version,4), t(reconnect_timeout,4)
                     ])
 
             wait(1 sec)
-            subscribe(sprintf("channels/~s/messages/#", [var("MF_CHANNEL_ID")]), numvar("QOS"))
+            subscribe(sprintf("channels/~s/messages/#", [var("MZBENCH_MF_CHANNEL_ID")]), numvar("MZBENCH_QOS"))
 
 
-pool(size = numvar("PUB_NUM"),
+pool(size = numvar("MZBENCH_PUB_NUM"),
      worker_type = mqtt_worker,
-     worker_start = poisson(numvar("PUB_NUM") rps)):
-            connect([t(host, var("MF_MQTT_ENDPOINT")),
-                    t(port, numvar("MF_MQTT_PORT")),
+     worker_start = poisson(numvar("MZBENCH_PUB_NUM") rps)):
+            connect([t(host, var("MZBENCH_MF_MQTT_ENDPOINT")),
+                    t(port, numvar("MZBENCH_MF_MQTT_PORT")),
                     t(client,fixed_client_id("publisher", worker_id())),
                     t(clean_session,true),
                     t(keepalive_interval,60),
-                    t(username, var("MF_THING_2_ID")),
-                    t(password, var("MF_THING_2_KEY")),
+                    t(username, var("MZBENCH_MF_THING_2_ID")),
+                    t(password, var("MZBENCH_MF_THING_2_KEY")),
                     t(proto_version,4), t(reconnect_timeout,4)
                     ])
 
             set_signal(connect1, 1)
-            wait_signal(connect1, numvar("PUB_NUM"))
+            wait_signal(connect1, numvar("MZBENCH_PUB_NUM"))
             wait(5 sec)
-            loop(time = numvar("PUB_TIME") min, rate = numvar("PUB_RATE") rps):
-                publish_to_self(sprintf("channels/~s/messages/", [var("MF_CHANNEL_ID")]), random_binary(numvar("MSG_SIZE")), numvar("QOS"))
+            loop(time = numvar("MZBENCH_PUB_TIME") min, rate = numvar("MZBENCH_PUB_RATE") rps):
+                publish_to_self(sprintf("channels/~s/messages/", [var("MZBENCH_MF_CHANNEL_ID")]), random_binary(numvar("MZBENCH_MSG_SIZE")), numvar("MZBENCH_QOS"))
             disconnect()

--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -8,7 +8,7 @@
 # Message size: 100 random bytes
 # Running time: 5 min
 # QoS level: 2
-# NOTE: Update values in test, according to your values
+# NOTE: Update values in defaults or set environment variables according to your values
 # <MF_MQTT_ENPOINT> = IP/domain of your MQTT endpoint
 # <MF_THING_1_ID> = First thing ID of pre-provisioned Mainflux thing
 # <MF_THING_1_key> = First thing key of pre-provisioned Mainflux thing

--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -2,31 +2,31 @@
 
 #######
 # Scenario:
-# A single subscriber reading from "channels/<MZBENCH_MF_CHANNEL_ID>/messages/#" topic
-# 10000 publisher publishing to exclusive topic "channels/<MZBENCH_MF_CHANNEL_ID>/messages/<client_id>"
+# A single subscriber reading from "channels/<MF_MZBENCH_CHANNEL_ID>/messages/#" topic
+# 10000 publisher publishing to exclusive topic "channels/<MF_MZBENCH_CHANNEL_ID>/messages/<client_id>"
 # Overall msg rate: 10 000 msg/s
 # Message size: 100 random bytes
 # Running time: 5 min
 # QoS level: 2
 # NOTE: Scenario's values can be changed with environment variables predefined in defaults
 # Set environment variables to connect to Mainflux instance:
-# MZBENCH_MF_MQTT_ENPOINT = IP/domain of MQTT endpoint on Mainflux
-# MZBENCH_MF_MQTT_PORT = Port of MQTT endpoint on Mainflux
-# MZBENCH_MF_THING_1_ID = First thing ID of pre-provisioned Mainflux thing
-# MZBENCH_MF_THING_1_KEY = First thing key of pre-provisioned Mainflux thing
-# MZBENCH_MF_THING_2_ID = Second thing ID of pre-provisioned Mainflux thing
-# MZBENCH_MF_THING_2_KEY = Second thing key of pre-provisioned Mainflux thing.
-# MZBENCH_MF_CHANNEL_ID = ID of pre-provisioned channel on which both things are connected
+# MF_MZBENCH_MQTT_ENPOINT = IP/domain of MQTT endpoint on Mainflux
+# MF_MZBENCH_MQTT_PORT = Port of MQTT endpoint on Mainflux
+# MF_MZBENCH_THING_1_ID = First thing ID of pre-provisioned Mainflux thing
+# MF_MZBENCH_THING_1_KEY = First thing key of pre-provisioned Mainflux thing
+# MF_MZBENCH_THING_2_ID = Second thing ID of pre-provisioned Mainflux thing
+# MF_MZBENCH_THING_2_KEY = Second thing key of pre-provisioned Mainflux thing.
+# MF_MZBENCH_CHANNEL_ID = ID of pre-provisioned channel on which both things are connected
 #######
 
 defaults(
-        "MZBENCH_PUB_NUM" = 10000,
-        "MZBENCH_PUB_TIME" = 5,
-        "MZBENCH_PUB_RATE" = 1,
-        "MZBENCH_MSG_SIZE" = 100,
-        "MZBENCH_QOS" = 2,
-        "MZBENCH_MF_MQTT_ENDPOINT" = "127.0.0.1",
-        "MZBENCH_MF_MQTT_PORT" = 1883
+        "MF_MZBENCH_PUB_NUM" = 10000,
+        "MF_MZBENCH_PUB_TIME" = 5,
+        "MF_MZBENCH_PUB_RATE" = 1,
+        "MF_MZBENCH_MSG_SIZE" = 100,
+        "MF_MZBENCH_QOS" = 2,
+        "MF_MZBENCH_MQTT_ENDPOINT" = "127.0.0.1",
+        "MF_MZBENCH_MQTT_PORT" = 1883
 )
 
 make_install(git = "https://github.com/erlio/vmq_mzbench.git",
@@ -34,36 +34,36 @@ make_install(git = "https://github.com/erlio/vmq_mzbench.git",
 
 pool(size = 1,
      worker_type = mqtt_worker):
-            connect([t(host, var("MZBENCH_MF_MQTT_ENDPOINT")),
-                    t(port, numvar("MZBENCH_MF_MQTT_PORT")),
+            connect([t(host, var("MF_MZBENCH_MQTT_ENDPOINT")),
+                    t(port, numvar("MF_MZBENCH_MQTT_PORT")),
                     t(client,"subscriber1"),
                     t(clean_session,true),
                     t(keepalive_interval,60),
-                    t(username, var("MZBENCH_MF_THING_1_ID")),
-                    t(password, var("MZBENCH_MF_THING_1_KEY")),
+                    t(username, var("MF_MZBENCH_THING_1_ID")),
+                    t(password, var("MF_MZBENCH_THING_1_KEY")),
                     t(proto_version,4), t(reconnect_timeout,4)
                     ])
 
             wait(1 sec)
-            subscribe(sprintf("channels/~s/messages/#", [var("MZBENCH_MF_CHANNEL_ID")]), numvar("MZBENCH_QOS"))
+            subscribe(sprintf("channels/~s/messages/#", [var("MF_MZBENCH_CHANNEL_ID")]), numvar("MF_MZBENCH_QOS"))
 
 
-pool(size = numvar("MZBENCH_PUB_NUM"),
+pool(size = numvar("MF_MZBENCH_PUB_NUM"),
      worker_type = mqtt_worker,
-     worker_start = poisson(numvar("MZBENCH_PUB_NUM") rps)):
-            connect([t(host, var("MZBENCH_MF_MQTT_ENDPOINT")),
-                    t(port, numvar("MZBENCH_MF_MQTT_PORT")),
+     worker_start = poisson(numvar("MF_MZBENCH_PUB_NUM") rps)):
+            connect([t(host, var("MF_MZBENCH_MQTT_ENDPOINT")),
+                    t(port, numvar("MF_MZBENCH_MQTT_PORT")),
                     t(client,fixed_client_id("publisher", worker_id())),
                     t(clean_session,true),
                     t(keepalive_interval,60),
-                    t(username, var("MZBENCH_MF_THING_2_ID")),
-                    t(password, var("MZBENCH_MF_THING_2_KEY")),
+                    t(username, var("MF_MZBENCH_THING_2_ID")),
+                    t(password, var("MF_MZBENCH_THING_2_KEY")),
                     t(proto_version,4), t(reconnect_timeout,4)
                     ])
 
             set_signal(connect1, 1)
-            wait_signal(connect1, numvar("MZBENCH_PUB_NUM"))
+            wait_signal(connect1, numvar("MF_MZBENCH_PUB_NUM"))
             wait(5 sec)
-            loop(time = numvar("MZBENCH_PUB_TIME") min, rate = numvar("MZBENCH_PUB_RATE") rps):
-                publish_to_self(sprintf("channels/~s/messages/", [var("MZBENCH_MF_CHANNEL_ID")]), random_binary(numvar("MZBENCH_MSG_SIZE")), numvar("MZBENCH_QOS"))
+            loop(time = numvar("MF_MZBENCH_PUB_TIME") min, rate = numvar("MF_MZBENCH_PUB_RATE") rps):
+                publish_to_self(sprintf("channels/~s/messages/", [var("MF_MZBENCH_CHANNEL_ID")]), random_binary(numvar("MF_MZBENCH_MSG_SIZE")), numvar("MF_MZBENCH_QOS"))
             disconnect()

--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -2,8 +2,8 @@
 
 #######
 # Scenario:
-# A single subscriber reading from "<MF_CHANNEL>/#" topic
-# 10000 publisher publishing to exclusive topic "<MF_CHANNEL>/<client_id>"
+# A single subscriber reading from "channels/<MF_CHANNEL_ID>/messages/#" topic
+# 10000 publisher publishing to exclusive topic "channels/<MF_CHANNEL_ID>/messages/<client_id>"
 # Overall msg rate: 10 000 msg/s
 # Message size: 100 random bytes
 # Running time: 5 min
@@ -17,41 +17,56 @@
 # <MF_CHANNEL> = pre-provisioned channel where thing is connected
 #######
 
+defaults(
+        "PUB_SIZE" = 10000,
+        "PUB_TIME" = 5,
+        "PUB_RATE" = 1,
+        "MSG_SIZE" = 100,
+        "QOS" = 2,
+        "MF_MQTT_ENDPOINT" = "127.0.0.1",
+        "MF_MQTT_PORT" = 1883,
+        "MQTT_THING_1_ID" = "<MQTT_THING_1_ID>",
+        "MQTT_THING_1_KEY" = "<MQTT_THING_1_KEY>",
+        "MQTT_THING_2_ID" = "<MQTT_THING_2_ID>",
+        "MQTT_THING_2_KEY" = "<MQTT_THING_2_KEY>",
+        "MF_CHANNEL_ID" = "<MF_CHANNEL_ID>"
+)
+
 make_install(git = "https://github.com/erlio/vmq_mzbench.git",
              branch = "master")
 
 pool(size = 1,
      worker_type = mqtt_worker):
-            connect([t(host, "<MF_MQTT_ENDPOINT>"),
-                    t(port, 1883),
+            connect([t(host, var("MF_MQTT_ENDPOINT")),
+                    t(port, numvar("MF_MQTT_PORT")),
                     t(client,"subscriber1"),
                     t(clean_session,true),
                     t(keepalive_interval,60),
-                    t(username, "<MQTT_THING_1_ID>"),
-                    t(password, "<MQTT_THING_1_KEY>"),
+                    t(username, var("MQTT_THING_1_ID")),
+                    t(password, var("MQTT_THING_1_KEY")),
                     t(proto_version,4), t(reconnect_timeout,4)
                     ])
 
             wait(1 sec)
-            subscribe("<MF_CHANNEL>/#", 2)
+            subscribe(sprintf("channels/~s/messages/#", [var("MF_CHANNEL_ID")]), numvar("QOS"))
 
 
-pool(size = 10000,
+pool(size = numvar("PUB_SIZE"),
      worker_type = mqtt_worker,
-     worker_start = poisson(10000 rps)):
-            connect([t(host, "<MF_MQTT_ENDPOINT>"),
-                    t(port, 1883),
-                    t(client,fixed_client_id("publisher-", worker_id())),
+     worker_start = poisson(numvar("PUB_SIZE") rps)):
+            connect([t(host, var("MF_MQTT_ENDPOINT")),
+                    t(port, numvar("MF_MQTT_PORT")),
+                    t(client,fixed_client_id("publisher", worker_id())),
                     t(clean_session,true),
                     t(keepalive_interval,60),
-                    t(username, "<MQTT_THING_2_ID>"),
-                    t(password, "<MQTT_THING_2_KEY>"),
+                    t(username, var("MQTT_THING_2_ID")),
+                    t(password, var("MQTT_THING_2_KEY")),
                     t(proto_version,4), t(reconnect_timeout,4)
                     ])
 
             set_signal(connect1, 1)
-            wait_signal(connect1, 10000)
+            wait_signal(connect1, numvar("PUB_SIZE"))
             wait(5 sec)
-            loop(time = 5 min, rate = 1 rps):
-                publish_to_self("<MF_CHANNEL>/", random_binary(100), 2)
+            loop(time = numvar("PUB_TIME") min, rate = numvar("PUB_RATE") rps):
+                publish_to_self(sprintf("channels/~s/messages/", [var("MF_CHANNEL_ID")]), random_binary(numvar("MSG_SIZE")), numvar("QOS"))
             disconnect()

--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -8,13 +8,15 @@
 # Message size: 100 random bytes
 # Running time: 5 min
 # QoS level: 2
-# NOTE: Update values in defaults or set environment variables according to your values
-# <MF_MQTT_ENPOINT> = IP/domain of your MQTT endpoint
-# <MF_THING_1_ID> = First thing ID of pre-provisioned Mainflux thing
-# <MF_THING_1_KEY> = First thing key of pre-provisioned Mainflux thing
-# <MF_THING_2_ID> = Second thing ID of pre-provisioned Mainflux thing
-# <MF_THING_2_KEY> = Second thing key of pre-provisioned Mainflux thing.
-# <MF_CHANNEL_ID> = pre-provisioned channel id where things are connected
+# NOTE: Scenario's values can be changed with environment variables predefined in defaults
+# Set environment variables to connect to Mainflux instance:
+# MF_MQTT_ENPOINT = IP/domain of MQTT endpoint on Mainflux
+# MF_MQTT_PORT = Port of MQTT endpoint on Mainflux
+# MF_THING_1_ID = First thing ID of pre-provisioned Mainflux thing
+# MF_THING_1_KEY = First thing key of pre-provisioned Mainflux thing
+# MF_THING_2_ID = Second thing ID of pre-provisioned Mainflux thing
+# MF_THING_2_KEY = Second thing key of pre-provisioned Mainflux thing.
+# MF_CHANNEL_ID = ID of pre-provisioned channel on which both things are connected
 #######
 
 defaults(
@@ -24,12 +26,7 @@ defaults(
         "MSG_SIZE" = 100,
         "QOS" = 2,
         "MF_MQTT_ENDPOINT" = "127.0.0.1",
-        "MF_MQTT_PORT" = 1883,
-        "MF_THING_1_ID" = "<MF_THING_1_ID>",
-        "MF_THING_1_KEY" = "<MF_THING_1_KEY>",
-        "MF_THING_2_ID" = "<MF_THING_2_ID>",
-        "MF_THING_2_KEY" = "<MF_THING_2_KEY>",
-        "MF_CHANNEL_ID" = "<MF_CHANNEL_ID>"
+        "MF_MQTT_PORT" = 1883
 )
 
 make_install(git = "https://github.com/erlio/vmq_mzbench.git",

--- a/mzbench/scenarios/fan_in.bdl
+++ b/mzbench/scenarios/fan_in.bdl
@@ -11,9 +11,9 @@
 # NOTE: Update values in defaults or set environment variables according to your values
 # <MF_MQTT_ENPOINT> = IP/domain of your MQTT endpoint
 # <MF_THING_1_ID> = First thing ID of pre-provisioned Mainflux thing
-# <MF_THING_1_key> = First thing key of pre-provisioned Mainflux thing
+# <MF_THING_1_KEY> = First thing key of pre-provisioned Mainflux thing
 # <MF_THING_2_ID> = Second thing ID of pre-provisioned Mainflux thing
-# <MF_THING_2_key> = Second thing key of pre-provisioned Mainflux thing.
+# <MF_THING_2_KEY> = Second thing key of pre-provisioned Mainflux thing.
 # <MF_CHANNEL> = pre-provisioned channel where thing is connected
 #######
 
@@ -25,10 +25,10 @@ defaults(
         "QOS" = 2,
         "MF_MQTT_ENDPOINT" = "127.0.0.1",
         "MF_MQTT_PORT" = 1883,
-        "MQTT_THING_1_ID" = "<MQTT_THING_1_ID>",
-        "MQTT_THING_1_KEY" = "<MQTT_THING_1_KEY>",
-        "MQTT_THING_2_ID" = "<MQTT_THING_2_ID>",
-        "MQTT_THING_2_KEY" = "<MQTT_THING_2_KEY>",
+        "MF_THING_1_ID" = "<MF_THING_1_ID>",
+        "MF_THING_1_KEY" = "<MF_THING_1_KEY>",
+        "MF_THING_2_ID" = "<MF_THING_2_ID>",
+        "MF_THING_2_KEY" = "<MF_THING_2_KEY>",
         "MF_CHANNEL_ID" = "<MF_CHANNEL_ID>"
 )
 
@@ -42,8 +42,8 @@ pool(size = 1,
                     t(client,"subscriber1"),
                     t(clean_session,true),
                     t(keepalive_interval,60),
-                    t(username, var("MQTT_THING_1_ID")),
-                    t(password, var("MQTT_THING_1_KEY")),
+                    t(username, var("MF_THING_1_ID")),
+                    t(password, var("MF_THING_1_KEY")),
                     t(proto_version,4), t(reconnect_timeout,4)
                     ])
 
@@ -59,8 +59,8 @@ pool(size = numvar("PUB_NUM"),
                     t(client,fixed_client_id("publisher", worker_id())),
                     t(clean_session,true),
                     t(keepalive_interval,60),
-                    t(username, var("MQTT_THING_2_ID")),
-                    t(password, var("MQTT_THING_2_KEY")),
+                    t(username, var("MF_THING_2_ID")),
+                    t(password, var("MF_THING_2_KEY")),
                     t(proto_version,4), t(reconnect_timeout,4)
                     ])
 


### PR DESCRIPTION
Scenario stays same with default values, these changes do not affect the benchmark results.

- Move scenario values to environment variables with default values 
- Move mainflux values to environment variables
- Remove extra dash from client id

Signed-off-by: Ivan Milošević <iva@blokovi.com>